### PR TITLE
sweetalert2-react-content추가 및 인풋 리셋 버그와 alert 버그 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-scripts": "4.0.3",
     "styled-components": "^5.3.0",
     "sweetalert2": "^11.0.8",
+    "sweetalert2-react-content": "^4.0.1",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"
   },

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { styled } from '@material-ui/core/styles';
 import Logo from '../../images/softwareLogo_origin.png';
 import media from '../../lib/styles/media';
 import { Button, Container, TextField } from '@material-ui/core';
 import { Redirect, useHistory } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import FadeIn from 'react-fade-in';
 import useSignInWithEmailAndPassword from '../../hooks/useSignInWithEmailAndPassword';
 import { auth } from '../../config/firebase.config';
-import Swal from 'sweetalert2';
 import customSwal from '../../utils/alert';
 import getFirebaseErrorMessage from '../../utils/error/firebase';
 import { useAppDispatch } from '../../redux/hooks';
@@ -22,22 +21,7 @@ export type LoginInput = {
 };
 
 function Login({}: LoginProps) {
-  const {
-    register,
-    handleSubmit,
-    watch,
-    reset,
-    formState: { errors },
-  } = useForm<LoginInput>();
-
-  const onSubmit = async (data: LoginInput) => {
-    await signInwithEmailAndPassword(
-      `${data.studentID}@sejongCabinet.com`,
-      data.password,
-    );
-    reset({ studentID: '', password: '' });
-    console.log(user);
-  };
+  const { handleSubmit, control, reset, formState } = useForm<LoginInput>();
 
   const history = useHistory();
 
@@ -50,13 +34,27 @@ function Login({}: LoginProps) {
     dispatch(setUserUID(uid));
   };
 
-  if (error) {
+  const onSubmit = useCallback(async (data: LoginInput) => {
+    await signInwithEmailAndPassword(
+      `${data.studentID}@sejongCabinet.com`,
+      data.password,
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!error) return;
     customSwal(
       'error',
       '로그인 에러입니다.',
-      getFirebaseErrorMessage(error.code),
+      getFirebaseErrorMessage(error?.code),
     );
-  }
+  }, [error]);
+
+  useEffect(() => {
+    if (formState.isSubmitSuccessful) {
+      reset({ studentID: '', password: '' });
+    }
+  }, [formState, reset]);
 
   if (loading) {
     return <div>로딩중...</div>;
@@ -74,26 +72,40 @@ function Login({}: LoginProps) {
         <LogoTitle>SEJONG UNIV</LogoTitle>
         <LogoTitle2>소프트웨어학과 사물함</LogoTitle2>
         <LoginForm onSubmit={handleSubmit(onSubmit)}>
-          <LoginTextField
-            label="학번"
-            variant="outlined"
-            {...register('studentID', {
-              required: true,
-              // minLength: 8,
-              // maxLength: 8,
-            })}
-            // inputProps={{ maxLength: 8 }}
-            helperText={errors.studentID && '학번 8자리를 입력해주세요.'}
+          <Controller
+            name="studentID"
+            control={control}
+            defaultValue=""
+            rules={{ required: true, minLength: 8, maxLength: 8 }}
+            render={({ field: { onChange, value }, fieldState: { error } }) => (
+              <LoginTextField
+                label="학번"
+                variant="outlined"
+                onChange={onChange}
+                value={value}
+                error={!!error}
+                helperText={error ? '학번 8자리를 입력해주세요.' : null}
+              />
+            )}
           />
-          <LoginTextField
-            label="비밀번호"
-            variant="outlined"
-            type="password"
-            {...register('password', { required: true, minLength: 6 })}
-            inputProps={{ maxLength: 12 }}
-            helperText={
-              errors.password && '6글자 이상의 패스워드를 입력해주세요.'
-            }
+          <Controller
+            name="password"
+            control={control}
+            defaultValue=""
+            rules={{ required: true, minLength: 6 }}
+            render={({ field: { onChange, value }, fieldState: { error } }) => (
+              <LoginTextField
+                label="비밀번호"
+                variant="outlined"
+                type="password"
+                value={value}
+                onChange={onChange}
+                error={!!error}
+                helperText={
+                  error ? '6글자 이상의 패스워드를 입력해주세요.' : null
+                }
+              />
+            )}
           />
           <LoginButton type="submit" variant="contained">
             로그인

--- a/src/utils/alert/index.ts
+++ b/src/utils/alert/index.ts
@@ -1,9 +1,12 @@
 import Swal from 'sweetalert2';
+import withReactContent from 'sweetalert2-react-content';
 
 type swalIconType = 'warning' | 'error' | 'success' | 'info' | 'question';
 
+const MySwal = withReactContent(Swal);
+
 const customSwal = (icon: swalIconType, title: string, text: string | null) => {
-  return Swal.fire({
+  return MySwal.fire({
     icon,
     title,
     text: text || '',

--- a/src/utils/error/firebase/errorType.ts
+++ b/src/utils/error/firebase/errorType.ts
@@ -94,5 +94,4 @@ export const UID_ALREADY_EXISTS =
   '제공된 uid를 기존 사용자가 이미 사용하고 있습니다. 각 사용자마다 uid가 고유해야 합니다.';
 export const UNAUTHORIZED_CONTINUE_URI =
   '연결 URL의 도메인이 허용 목록에 포함되어 있지 않습니다. Firebase Console에서 도메인을 허용해야 합니다.';
-export const USER_NOT_FOUND =
-  '제공된 식별자에 해당하는 기존 사용자 레코드가 없습니다.';
+export const USER_NOT_FOUND = '존재하지 않는 아이디입니다.';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11377,6 +11377,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+sweetalert2-react-content@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/sweetalert2-react-content/-/sweetalert2-react-content-4.0.1.tgz#fdbbc0010095ec9aaccb5549a8f9f57500aa477e"
+  integrity sha512-vS7/k1BplmX72O0lFp2eG7+FsCvrZ9VOgKNHE2wUx1tbeKx+DLEPgAHnQ19DNhbdleRTW8o998atBmYjCkdg7Q==
+
 sweetalert2@^11.0.8:
   version "11.0.8"
   resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.0.8.tgz#4c03d92983de4616a8130d8c9ab12175572f749f"


### PR DESCRIPTION
sweetalert2-react-content는 버그와는 크게 관련이 없었지만 다음과 같은 옵션이 가능해진다고해서 미리 올려두었음
- title
- html
- confirmButtonText
- denyButtonText
- cancelButtonText
- footer
- closeButtonHtml
- iconHtml

인풋 리셋 버그는 리액트 훅폼에서 controller 추가와 useEffect로 formState를 지켜보면서 해결하였음.

alert버그또한 기존의 if로 렌더링하는 방식이 맞지 않아서 useEffect로 에러를 지켜보고 해결하였음.

마지막으로 아이디 존재하지 않는 메시지를 직관적으로 변경하였음