### PR TITLE
파이어베이스 리덕스 연동 로직 변경 및 타입 재정의

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,60 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Route, Switch, BrowserRouter as Router } from 'react-router-dom';
 import MainPage from './pages/MainPage';
 import Login from './pages/Login';
 import SignUp from './pages/SignUp';
 import AdminPage from './pages/AdminPage';
 import UserPage from './pages/UserPage';
+import { auth, database } from './config/firebase.config';
+import { useObject } from './hooks/useObject';
+import { setServerStatus } from './redux/server/serverSlice';
+import useAuthState from './hooks/useAuthState';
+import {
+  setUserInfo,
+  setUserUID,
+  userInitialState,
+} from './redux/user/userSlice';
+import { useAppDispatch } from './redux/hooks';
 
 function App() {
+  const dispatch = useAppDispatch();
+  const [user, authLoading, authError] = useAuthState(auth);
+  const [userInfo, userInfoLoading, userInfoError] = useObject(
+    database.ref(`users/${user?.uid}`),
+  );
+
+  const [serverInfo, serverInfoLoading, serverInfoError] = useObject(
+    database.ref('server/status'),
+  );
+
+  // 파이어베이스 유저 데이터 리덕스로 옮기기
+  useEffect(() => {
+    if (user) {
+      dispatch(setUserUID(user.uid));
+    } else {
+      dispatch(setUserUID(null));
+      dispatch(setUserInfo(userInitialState));
+    }
+  }, [user]);
+
+  // 파이어베이스 유저 정보 데이터 리덕스로 옮기기
+  useEffect(() => {
+    if (userInfo?.val()) {
+      dispatch(setUserInfo(userInfo.val()));
+    }
+  }, [userInfo]);
+
+  // 파이어베이스 서버 데이터 리덕스로 옮기기
+  useEffect(() => {
+    if (serverInfo) {
+      dispatch(setServerStatus(serverInfo.val()));
+    }
+  }, [serverInfo]);
+
+  if (authLoading || userInfoLoading || serverInfoLoading) {
+    return <div>로딩중..</div>;
+  }
+
   return (
     <Router>
       <Switch>

--- a/src/Components/MenuInfo/MenuInfo.tsx
+++ b/src/Components/MenuInfo/MenuInfo.tsx
@@ -5,11 +5,11 @@ import { auth, database } from '../../config/firebase.config';
 import { useHistory, useLocation } from 'react-router';
 import useAuthState from '../../hooks/useAuthState';
 import { useObject } from '../../hooks/useObject';
+import { useAppSelector, useUserSelector } from '../../redux/hooks';
 
-export type MenuInfoProps = { name?: string };
-
-export default function MenuInfo({ name = '익명' }: MenuInfoProps) {
+export default function MenuInfo() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const { name } = useAppSelector(useUserSelector);
   const handleClose = useCallback(() => {
     setAnchorEl(null);
   }, []);
@@ -21,7 +21,7 @@ export default function MenuInfo({ name = '익명' }: MenuInfoProps) {
   }, []);
   return (
     <MenuContainer>
-      {`${name}님 환영합니다!`}
+      {`${name ?? '익명'}님 환영합니다!`}
       <HamburgerButton onClick={handleClick} disableRipple>
         <MenuIcon />
       </HamburgerButton>

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -1,21 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { styled } from '@material-ui/core/styles';
-import { Redirect, useHistory } from 'react-router-dom';
 import { Button, Container } from '@material-ui/core';
-import { useAppSelector } from '../../redux/hooks';
+import { useAppSelector, useServerSelector } from '../../redux/hooks';
 import Header from '../../Components/Header';
 import media from '../../lib/styles/media';
 import PasswordChangeForm from '../../Components/PasswordChangeForm';
-import { auth, database } from '../../config/firebase.config';
-import changeServerStatus from '../../utils/firebase/changeServerStatus';
+import changeFirebaseServerStatus from '../../utils/firebase/changeFirebaseServerStatus';
 
 export type AdminPageProps = {};
 
 function AdminPage({}: AdminPageProps) {
-  const cabinetTitle = useAppSelector((state) => state.users.cabinetTitle);
-  const cabinetIdx = useAppSelector((state) => state.users.cabinetIdx);
-  let serverStatus = useAppSelector((state) => state.server.status);
-
+  const { status } = useAppSelector(useServerSelector);
   const [total, setTotal] = useState(0);
 
   return (
@@ -26,8 +21,8 @@ function AdminPage({}: AdminPageProps) {
           <AdminPageTitle>관리자 페이지</AdminPageTitle>
           <MyCabinetContents>
             <MyCabinet>현재 예약된 사물함 : {total}개</MyCabinet>
-            <CancleButton onClick={() => changeServerStatus(serverStatus)}>
-              {serverStatus ? '서버 열기' : '서버 닫기'}
+            <CancleButton onClick={() => changeFirebaseServerStatus(status)}>
+              {status ? '서버 열기' : '서버 닫기'}
             </CancleButton>
           </MyCabinetContents>
         </AdminPageContents>

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -6,14 +6,11 @@ import { Button, Container, TextField } from '@material-ui/core';
 import { Redirect, useHistory } from 'react-router-dom';
 import { Controller, useForm } from 'react-hook-form';
 import useSignInWithEmailAndPassword from '../../hooks/useSignInWithEmailAndPassword';
-import { auth, database } from '../../config/firebase.config';
+import { auth } from '../../config/firebase.config';
 import customSwal from '../../utils/alert';
 import getFirebaseErrorMessage from '../../utils/error/firebase';
-import { useAppDispatch } from '../../redux/hooks';
-import { setUserUID } from '../../redux/user/userSlice';
-import { setServerStatus } from '../../redux/server/serverSlice';
+import { useAppSelector, useUserSelector } from '../../redux/hooks';
 import AppLayout from '../../Components/AppLayout';
-import useAuthState from '../../hooks/useAuthState';
 
 export type LoginProps = {};
 
@@ -24,24 +21,10 @@ export type LoginInput = {
 
 function Login({}: LoginProps) {
   const { handleSubmit, control, reset, formState } = useForm<LoginInput>();
-
   const history = useHistory();
-  const [user, authLoading, authError] = useAuthState(auth);
+  const { uuid } = useAppSelector(useUserSelector);
   const [signInwithEmailAndPassword, signInAfterUser, loading, error] =
     useSignInWithEmailAndPassword(auth);
-
-  const dispatch = useAppDispatch();
-
-  const saveUserInfo = (uid: string | undefined) => {
-    dispatch(setUserUID(uid));
-  };
-
-  const saveServerStatus = () => {
-    const status = database.ref('server/status').on('value', (snapshot) => {
-      dispatch(setServerStatus(snapshot.val()));
-    });
-  };
-
   const onSubmit = useCallback(async (data: LoginInput) => {
     await signInwithEmailAndPassword(
       `${data.studentID}@sejongCabinet.com`,
@@ -64,13 +47,7 @@ function Login({}: LoginProps) {
     }
   }, [formState, reset]);
 
-  if (authLoading || loading) {
-    return <div>로딩중...</div>;
-  }
-
-  if (user) {
-    saveUserInfo(user.uid);
-    saveServerStatus();
+  if (uuid) {
     return <Redirect to="/main" />;
   }
 

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -4,27 +4,18 @@ import HelperButton from '../../Components/HelperButton';
 import HelperModal from '../../Components/HelperModal';
 import { Redirect } from 'react-router-dom';
 import MenuInfo from '../../Components/MenuInfo';
-import { useObject } from '../../hooks/useObject';
-import { auth, database } from '../../config/firebase.config';
-import useAuthState from '../../hooks/useAuthState';
+import { useAppSelector, useUserSelector } from '../../redux/hooks';
 
 export type MainPageProps = {};
 
 function MainPage({}: MainPageProps) {
-  const [user, authLoading, authError] = useAuthState(auth);
-  const [userInfo, userInfoLoading, userInfoError] = useObject(
-    database.ref(`users/${user?.uid}`),
-  );
   const [openModal, setOpenModal] = useState<boolean>(false);
+  const { uuid } = useAppSelector(useUserSelector);
   const handleOpen = () => {
     setOpenModal(!openModal);
   };
 
-  if (authLoading || userInfoLoading) {
-    return <div>로딩중...</div>;
-  }
-
-  if (!user) {
+  if (!uuid) {
     return <Redirect to="/login" />;
   }
 
@@ -32,7 +23,7 @@ function MainPage({}: MainPageProps) {
     <>
       <Header>
         <HelperButton onClick={handleOpen} />
-        <MenuInfo name={userInfo?.val().name} />
+        <MenuInfo />
       </Header>
       <HelperModal open={openModal} setOpen={handleOpen} />
     </>

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { styled } from '@material-ui/core/styles';
-import { Redirect, useHistory } from 'react-router-dom';
 import { Button, Container } from '@material-ui/core';
-import { useAppSelector } from '../../redux/hooks';
+import { useAppSelector, useUserSelector } from '../../redux/hooks';
 import Header from '../../Components/Header';
 import media from '../../lib/styles/media';
 import PasswordChangeForm from '../../Components/PasswordChangeForm';
@@ -10,8 +9,7 @@ import PasswordChangeForm from '../../Components/PasswordChangeForm';
 export type UserPageProps = {};
 
 function UserPage({}: UserPageProps) {
-  const cabinetTitle = useAppSelector((state) => state.users.cabinetTitle);
-  const cabinetIdx = useAppSelector((state) => state.users.cabinetIdx);
+  const { cabinetTitle, cabinetIdx } = useAppSelector(useUserSelector);
 
   return (
     <PageContainer>

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -3,3 +3,5 @@ import type { RootState, AppDispatch } from './store';
 
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const useUserSelector = (state: RootState) => state.user;
+export const useServerSelector = (state: RootState) => state.server;

--- a/src/redux/server/serverSlice.ts
+++ b/src/redux/server/serverSlice.ts
@@ -1,18 +1,20 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+export type serverStatusType = 0 | 1; // 1 : 닫힌 상태, 0 : 열린 상태
+
 interface ServerState {
-  status: number | undefined;
+  status: serverStatusType;
 }
 
 const initialState: ServerState = {
-  status: undefined,
+  status: 0,
 };
 
 export const serverSlice = createSlice({
   name: 'server',
   initialState,
   reducers: {
-    setServerStatus: (state, action: PayloadAction<number | undefined>) => {
+    setServerStatus: (state, action: PayloadAction<serverStatusType>) => {
       state.status = action.payload;
     },
   },

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -4,7 +4,7 @@ import serverReducer from './server/serverSlice';
 
 export const store = configureStore({
   reducer: {
-    users: userReducer,
+    user: userReducer,
     server: serverReducer,
   },
 });

--- a/src/redux/user/userSlice.ts
+++ b/src/redux/user/userSlice.ts
@@ -1,33 +1,48 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-interface UserState {
-  uuid: string | undefined;
+export interface UserState {
+  uuid: string | null;
   adminType: 0 | 1;
   cabinetIdx: number;
   cabinetTitle: string;
   name: string;
-  studentID: number;
+  studentID: string;
 }
 
-const initialState: UserState = {
-  uuid: '',
+interface UserInfo {
+  adminType: UserState['adminType'];
+  cabinetIdx: UserState['cabinetIdx'];
+  cabinetTitle: UserState['cabinetTitle'];
+  name: UserState['name'];
+  studentID: UserState['studentID'];
+}
+
+export const userInitialState: UserState = {
+  uuid: null,
   adminType: 0,
   cabinetIdx: 0,
   cabinetTitle: '',
   name: '',
-  studentID: 0,
+  studentID: '',
 };
 
 export const userSlice = createSlice({
   name: 'user',
-  initialState,
+  initialState: userInitialState,
   reducers: {
-    setUserUID: (state, action: PayloadAction<string | undefined>) => {
+    setUserUID: (state, action: PayloadAction<UserState['uuid']>) => {
       state.uuid = action.payload;
+    },
+    setUserInfo: (state, { payload: info }: PayloadAction<UserInfo>) => {
+      state.adminType = info.adminType;
+      state.cabinetIdx = info.cabinetIdx;
+      state.cabinetTitle = info.cabinetTitle;
+      state.name = info.name;
+      state.studentID = info.studentID;
     },
   },
 });
 
-export const { setUserUID } = userSlice.actions;
+export const { setUserUID, setUserInfo } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/src/utils/firebase/changeFirebaseServerStatus.ts
+++ b/src/utils/firebase/changeFirebaseServerStatus.ts
@@ -1,6 +1,7 @@
 import { database } from '../../config/firebase.config';
+import { serverStatusType } from '../../redux/server/serverSlice';
 
-const changeServerStatus = (serverStatus: number | undefined) => {
+const changeFirebaseServerStatus = (serverStatus: serverStatusType) => {
   if (serverStatus === 0) {
     return database.ref(`server`).set({
       status: 1,
@@ -12,4 +13,4 @@ const changeServerStatus = (serverStatus: number | undefined) => {
   }
 };
 
-export default changeServerStatus;
+export default changeFirebaseServerStatus;


### PR DESCRIPTION
이제 파이어베이스의 데이터가 바뀔때마다 리덕스의 데이터를 변화시켜주는 행동을 App.tsx에서 취합니다.

이로 인해 다른 컴포넌트나 페이지에서는 useAppSelector를 이용해 리덕스의 상태를 가져올 수 있습니다.
또한 App.tsx에서 on으로 계속 파이어베이스 데이터를 리스너형식으로 대기하고 있기 때문에 바로바로 데이터가 리덕스로 최신화 됩니다.

파이어베이스의 데이터를 변화시키고 싶을 때는 firebase폴더에 함수를 만들어 변화시킵니다.

이러한 방식으로 일단 짜봤는데 혹시 다른 의견있으시면 제안해주셔도 좋을 것 같습니다 :)