### PR TITLE
메인페이지 PC화면 구성

### DIFF
--- a/src/Components/Cabinet/Cabinet.tsx
+++ b/src/Components/Cabinet/Cabinet.tsx
@@ -6,79 +6,13 @@ import { database } from '../../config/firebase.config';
 import media from '../../lib/styles/media';
 import CabinetButtons from '../CabinetButtons';
 
-export type CabinetProps = {};
+export type CabinetProps = { userData: any };
 
-const data = {
-  currentCabinets: [
-    {
-      width: 10,
-      height: 10,
-      title: 'CAB-A',
-      item: {
-        1: {
-          status: 1,
-          uuid: 'dasndalsndlaksd',
-          studentId: '15011145',
-          name: '허균',
-        },
-        2: {
-          status: 1,
-          uuid: 'dasndalsndlaksd',
-          studentId: '15011145',
-          name: '허균',
-        },
-        3: {
-          status: 1,
-          uuid: 'dasndalsndlaksd',
-          studentId: '15011145',
-          name: '허균',
-        },
-        4: {
-          status: 1,
-          uuid: 'dasndalsndlaksd',
-          studentId: '15011145',
-          name: '허균',
-        },
-        5: {
-          status: 1,
-          uuid: 'dasndalsndlaksd',
-          studentId: '15011145',
-          name: '허균',
-        },
-      },
-    },
-    { width: 10, height: 10, title: 'CAB-B' },
-    { width: 3, height: 3, title: 'CAB-C' },
-    { width: 6, height: 6, title: 'CAB-D' },
-    { width: 10, height: 6, title: 'CAB-E' },
-    { width: 12, height: 6, title: 'CAB-F' },
-    { width: 6, height: 6, title: 'CAB-G' },
-    { width: 10, height: 10, title: 'CAB-H' },
-    { width: 10, height: 10, title: 'CAB-I' },
-    { width: 10, height: 10, title: 'CAB-J' },
-    { width: 10, height: 10, title: 'CAB-K' },
-    { width: 10, height: 10, title: 'CAB-L' },
-    { width: 10, height: 10, title: 'CAB-A' },
-    { width: 10, height: 10, title: 'CAB-B' },
-    { width: 10, height: 10, title: 'CAB-C' },
-    { width: 10, height: 10, title: 'CAB-D' },
-    { width: 10, height: 10, title: 'CAB-E' },
-    { width: 10, height: 10, title: 'CAB-F' },
-    { width: 10, height: 10, title: 'CAB-G' },
-    { width: 10, height: 10, title: 'CAB-H' },
-    { width: 10, height: 10, title: 'CAB-I' },
-    { width: 10, height: 10, title: 'CAB-J' },
-    { width: 10, height: 10, title: 'CAB-K' },
-    { width: 10, height: 10, title: 'CAB-L' },
-    { width: 10, height: 10, title: 'CAB-M' },
-  ],
-};
+interface CabinetItem {
+  [key: string]: any;
+}
 
-const cabinetNames = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-
-const tabWidth = 100 / cabinetNames.length;
-
-export default function Cabinet({}: CabinetProps) {
+export default function Cabinet({ userData }: CabinetProps) {
   const [index, setIndex] = useState(0);
 
   const handleChangeIndex = (value: number) => {
@@ -90,8 +24,8 @@ export default function Cabinet({}: CabinetProps) {
   };
 
   const LoadContents = () => {
-    return cabinetNames.map((i, v) => {
-      return <CabinetButtons key={v} data={data.currentCabinets[v]} />;
+    return userData.currentCabinets.map((v: any, i: any) => {
+      return <CabinetButtons key={i} data={v} />;
     });
   };
 
@@ -108,18 +42,23 @@ export default function Cabinet({}: CabinetProps) {
   };
 
   const loadTabs = () => {
-    return cabinetNames.map((i) => {
-      return (
-        <CabinetTab
-          key={data.currentCabinets[i].title}
-          label={data.currentCabinets[i].title}
-        />
-      );
+    return userData.currentCabinets.map((v: any) => {
+      return <CabinetTab key={v.title} label={v.title} wrapped />;
     });
   };
 
   const showTabs = () => {
-    return <CabinetTabs onChange={handleChange}>{loadTabs()}</CabinetTabs>;
+    return (
+      <CabinetTabs
+        value={index}
+        onChange={handleChange}
+        variant="scrollable"
+        scrollButtons="on"
+        indicatorColor="primary"
+      >
+        {loadTabs()}
+      </CabinetTabs>
+    );
   };
 
   return (
@@ -134,21 +73,16 @@ export default function Cabinet({}: CabinetProps) {
 
 const CabinetContainer = styled('div')({
   marginTop: '12vh',
-  height: '80vh',
   width: '100vw',
-  backgroundColor: 'gray',
   display: 'flex',
   justifyContent: 'center',
-  overflow: 'visible',
 });
 
 const TabsContainer = styled('div')({
-  width: '80%',
-  backgroundColor: 'rgba(255,0,0,0.3)',
-  height: '9vh',
+  width: '90%',
 
   [`${media.medium}`]: {
-    width: '100%',
+    width: '95%',
   },
 });
 
@@ -157,22 +91,25 @@ const CabinetTabs = styled(Tabs)({
   width: '100%',
 });
 
+const CabinetSwipeableViews = styled(SwipeableViews)({
+  marginTop: '3.5vh',
+  border: '0.5vh solid lightgray',
+  borderRadius: '2vw',
+  padding: '2vh 0 2vh',
+  overflow: 'hidden',
+});
+
 const CabinetTab = styled(Tab)({
   fontSize: `2vw`,
   letterSpacing: '0.1px',
   borderRadius: '10px',
   fontFamily: 'Anton',
-  minWidth: `${tabWidth}%`,
+  minWidth: '20%',
+  maxWidth: '100%',
+  padding: '2vh 0',
 
   [`${media.medium}`]: {
-    maxWidth: `${tabWidth}%`,
-    fontSize: `${tabWidth / 20}vw`,
+    minWidth: '25%',
+    fontSize: '1rem',
   },
-});
-
-const CabinetSwipeableViews = styled(SwipeableViews)({
-  marginTop: '5vh',
-  border: '0.5vh solid lightgray',
-  borderRadius: '2vw',
-  width: '100%',
 });

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -10,6 +10,45 @@ import { useAppSelector, useUserSelector } from '../../redux/hooks';
 
 export type MainPageProps = {};
 
+let data: any = {
+  currentCabinets: [
+    { width: 10, height: 10, title: 'CAB-A', item: {} },
+    { width: 10, height: 50, title: 'CAB-B', item: {} },
+    { width: 3, height: 3, title: 'CAB-C', item: {} },
+    { width: 6, height: 6, title: 'CAB-D', item: {} },
+    { width: 10, height: 6, title: 'CAB-E', item: {} },
+    { width: 12, height: 6, title: 'CAB-F', item: {} },
+    { width: 13, height: 6, title: 'CAB-G', item: {} },
+  ],
+};
+
+const makeRandomStudentID = () => {
+  let temp = '1';
+
+  for (let i = 0; i < 7; i++) {
+    temp += Math.floor(Math.random() * 9);
+  }
+
+  return temp;
+};
+
+const createRandomUser = (data: any) => {
+  data.currentCabinets.forEach((v: any) => {
+    for (let i = 0; i < v.width * v.height; i++) {
+      v.item[i] = {
+        status: Math.floor(Math.random() * 3),
+        studentID: makeRandomStudentID(),
+        uuid: Math.random().toString(36).substr(2, 11),
+        name: `테스트${i}`,
+      };
+    }
+  });
+
+  return data;
+};
+
+const userData = createRandomUser(data);
+
 function MainPage({}: MainPageProps) {
   const [openModal, setOpenModal] = useState<boolean>(false);
   const { uuid } = useAppSelector(useUserSelector);
@@ -27,7 +66,7 @@ function MainPage({}: MainPageProps) {
         <HelperButton onClick={handleOpen} />
         <MenuInfo />
       </Header>
-      <Cabinet />
+      <Cabinet userData={userData} />
       <HelperModal open={openModal} setOpen={handleOpen} />
     </AppLayout>
   );


### PR DESCRIPTION
## 개발사항

1. 사물함 Tab의 width를 '25%'로 고정하고 슬라이드 버튼을 추가해서 사물함 개수가 늘어나도 동일한 크기로 보여집니다. 
-> 모바일에서도 Tab의 개수에 상관없이 동일한 크기로 보여집니다.
-> 사물함 개수가 5개 보다 작을 경우 탭이 중앙 정렬 되지 않고 왼쪽에 치우치는 문제가 있습니다.

2. 사물함을 '사물함 번호로 보기','이름으로 보기','학번으로 보기'의 세가지 종류로 확인 할 수 있습니다. 버튼 구성은 material-ui의 radio 버튼에 tooltip으로 설명을 추가했습니다.
-> 모바일 버전에서는 학번이나 이름을 나타내기 어려울 것 같아서 UI를 구성하면서 없애려고 합니다

3. 사물함의 최대 가로 길이와 최대 세로 길이를 PC화면으로 테스트 해본 결과 세로 길이는 스크롤로 구현하면 제한이 없을 것 같고 최대 길이는 12까지 가능 할 것 같습니다.
-> 모바일 환경이 중요할 것 같은데 모바일 환경에서 최대 가로 길이에 따라서 사물함의 가로 길이 제한을 정해야 할 것 같습니다

## 이후계획

1. 신청 버튼의 함수를 제작하려고 합니다.
2. 모바일 UI도 마저 끝내겠습니다