### PR TITLE
feat : 관리자 기능 사물함 가로 세로 바꾸기 기능 추가

### DIFF
--- a/src/redux/cabinet/cabinetSlice.ts
+++ b/src/redux/cabinet/cabinetSlice.ts
@@ -11,7 +11,7 @@ export type CabinetTabType = {
   item: CabinetItemType[];
 };
 
-type CabinetItemType = {
+export type CabinetItemType = {
   status: number;
   uuid?: string;
   studentId?: string;

--- a/src/utils/firebase/changeFirebaseCabinetTab.ts
+++ b/src/utils/firebase/changeFirebaseCabinetTab.ts
@@ -23,7 +23,6 @@ export default function changeFirebaseCabinetTab(
           store.getState().cabinet.cabinet?.[cabinetNum].item;
         getCabinetItem?.map((item) => {
           // 사물함 돌아다니며 예약되어 있는 사용자 아이디의 예약 정보 초기화
-          console.log(item);
           if (item.uuid) {
             changeFirebaseCancelCabinetUser(item.uuid);
           }

--- a/src/utils/firebase/changeFirebaseCabinetTab.ts
+++ b/src/utils/firebase/changeFirebaseCabinetTab.ts
@@ -1,5 +1,8 @@
+import { CabinetItemType } from './../../redux/cabinet/cabinetSlice';
 import { database } from '../../config/firebase.config';
+import { store } from '../../redux/store';
 import customSwal from '../alert';
+import changeFirebaseCancelCabinetUser from './changeFirebaseCancelCabinetUser';
 
 export default function changeFirebaseCabinetTab(
   cabinetNum: number,
@@ -16,7 +19,24 @@ export default function changeFirebaseCabinetTab(
       true,
     ).then((result) => {
       if (result.isConfirmed) {
-        console.log('사물함 초기화');
+        const getCabinetItem =
+          store.getState().cabinet.cabinet?.[cabinetNum].item;
+        getCabinetItem?.map((item) => {
+          // 사물함 돌아다니며 예약되어 있는 사용자 아이디의 예약 정보 초기화
+          console.log(item);
+          if (item.uuid) {
+            changeFirebaseCancelCabinetUser(item.uuid);
+          }
+        });
+        // 가로 세로 정보 바꾸고 모든 아이템을 0으로 초기화
+        const itemObject: CabinetItemType[] = [];
+        for (let i = 0; i < cabinetWidth * cabinetHeight; i += 1) {
+          itemObject.push({ status: 0 });
+        }
+        database.ref(`cabinet/${cabinetNum}/width`).set(cabinetWidth);
+        database.ref(`cabinet/${cabinetNum}/height`).set(cabinetHeight);
+        database.ref(`cabinet/${cabinetNum}/item`).set(itemObject);
+        database.ref(`cabinet/${cabinetNum}/title`).set(cabinetTitle);
       }
     });
   } else {

--- a/src/utils/firebase/changeFirebaseCancelCabinetUser.ts
+++ b/src/utils/firebase/changeFirebaseCancelCabinetUser.ts
@@ -1,0 +1,12 @@
+import { database } from '../../config/firebase.config';
+import { serverStatusType } from '../../redux/server/serverSlice';
+
+const changeFirebaseCancelCabinetUser = (uuid: string) => {
+  const postData = {
+    cabinetIdx: 0,
+    cabinetTitle: 0,
+  };
+  return database.ref(`/users/${uuid}`).update(postData);
+};
+
+export default changeFirebaseCancelCabinetUser;


### PR DESCRIPTION
가로 세로를 바꾸는 기능을 추가하였습니다.
이 때, 해당 사물함에 예약되어 있는 사용자가 있다면 그 사용자들의 uuid를 찾아, 사용자 uuid 데이터 베이스에 들어가서 사용자 예약정보를 초기화 시켜줍니다. 그 후 사물함 가로 세로 개수를 바꾸고 가로 x 세로  갯수 만큼 사물함 item {status: 0} 을 초기화 시켜줍니다.