### PR TITLE
fix : 사물함 사물함 예약 취소 가능 수정, 사물함 삭제 기능 추가

### DIFF
--- a/src/Components/CabinetManageItem/CabinetManageItem.tsx
+++ b/src/Components/CabinetManageItem/CabinetManageItem.tsx
@@ -12,7 +12,9 @@ import {
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { useState } from 'react';
 import { CabinetTabType } from '../../redux/cabinet/cabinetSlice';
+import customSwal from '../../utils/alert';
 import changeFirebaseCabinetTab from '../../utils/firebase/changeFirebaseCabinetTab';
+import initializeFirebaseCabinetTab from '../../utils/firebase/initializeFirebaseCabinetTab';
 
 type CabinetManageItemProps = {
   item: CabinetTabType;
@@ -30,6 +32,19 @@ export default function CabinetManageItem({
     const isDifferent = width !== item.width || height !== item.height;
     console.log(isDifferent);
     changeFirebaseCabinetTab(index, title, width, height, isDifferent);
+  };
+  const handleInitialize = () => {
+    customSwal(
+      'warning',
+      '사물함 초기화 주의!',
+      '현재 등록된 사물함탭이 전부 예약가능 상태로 초기화 됩니다. 정말 사물함을 초기화 하시겠습니까?',
+      true,
+    ).then((result) => {
+      if (result.isConfirmed) {
+        initializeFirebaseCabinetTab(index);
+        // 가로 세로 정보 바꾸고 모든 아이템을 0으로 초기화
+      }
+    });
   };
   return (
     <Accordion>
@@ -73,7 +88,11 @@ export default function CabinetManageItem({
       </AccordionDetails>
       <Divider />
       <AccordionActions>
-        <Button size="small" style={{ color: 'red' }}>
+        <Button
+          size="small"
+          style={{ color: 'red' }}
+          onClick={handleInitialize}
+        >
           해당 탭의 사물함 초기화하기
         </Button>
         <Button size="small" style={{ color: 'red' }}>

--- a/src/Components/CabinetManageItem/CabinetManageItem.tsx
+++ b/src/Components/CabinetManageItem/CabinetManageItem.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react';
 import { CabinetTabType } from '../../redux/cabinet/cabinetSlice';
 import customSwal from '../../utils/alert';
 import changeFirebaseCabinetTab from '../../utils/firebase/changeFirebaseCabinetTab';
+import deleteFirebaseCabinetTab from '../../utils/firebase/deleteFirebaseCabinetTab';
 import initializeFirebaseCabinetTab from '../../utils/firebase/initializeFirebaseCabinetTab';
 
 type CabinetManageItemProps = {
@@ -45,6 +46,9 @@ export default function CabinetManageItem({
         // 가로 세로 정보 바꾸고 모든 아이템을 0으로 초기화
       }
     });
+  };
+  const handleDelete = () => {
+    deleteFirebaseCabinetTab(index);
   };
   return (
     <Accordion>
@@ -95,7 +99,7 @@ export default function CabinetManageItem({
         >
           해당 탭의 사물함 초기화하기
         </Button>
-        <Button size="small" style={{ color: 'red' }}>
+        <Button size="small" style={{ color: 'red' }} onClick={handleDelete}>
           삭제하기
         </Button>
         <Button size="small" color="primary" onClick={handleSubmit}>

--- a/src/utils/firebase/changeFirebaseCabinetTab.ts
+++ b/src/utils/firebase/changeFirebaseCabinetTab.ts
@@ -3,6 +3,7 @@ import { database } from '../../config/firebase.config';
 import { store } from '../../redux/store';
 import customSwal from '../alert';
 import changeFirebaseCancelCabinetUser from './changeFirebaseCancelCabinetUser';
+import initializeFirebaseCabinetTab from './initializeFirebaseCabinetTab';
 
 export default function changeFirebaseCabinetTab(
   cabinetNum: number,
@@ -19,14 +20,7 @@ export default function changeFirebaseCabinetTab(
       true,
     ).then((result) => {
       if (result.isConfirmed) {
-        const getCabinetItem =
-          store.getState().cabinet.cabinet?.[cabinetNum].item;
-        getCabinetItem?.map((item) => {
-          // 사물함 돌아다니며 예약되어 있는 사용자 아이디의 예약 정보 초기화
-          if (item.uuid) {
-            changeFirebaseCancelCabinetUser(item.uuid);
-          }
-        });
+        initializeFirebaseCabinetTab(cabinetNum);
         // 가로 세로 정보 바꾸고 모든 아이템을 0으로 초기화
         const itemObject: CabinetItemType[] = [];
         for (let i = 0; i < cabinetWidth * cabinetHeight; i += 1) {

--- a/src/utils/firebase/changeFirebaseCancelCabinetUser.ts
+++ b/src/utils/firebase/changeFirebaseCancelCabinetUser.ts
@@ -1,11 +1,16 @@
 import { database } from '../../config/firebase.config';
 import { serverStatusType } from '../../redux/server/serverSlice';
 
-const changeFirebaseCancelCabinetUser = (uuid: string) => {
+const changeFirebaseCancelCabinetUser = (
+  cabinetNum: number,
+  index: number,
+  uuid: string,
+) => {
   const postData = {
     cabinetIdx: 0,
     cabinetTitle: 0,
   };
+  database.ref(`/cabinet/${cabinetNum}/item/${index}`).set({ status: 0 });
   return database.ref(`/users/${uuid}`).update(postData);
 };
 

--- a/src/utils/firebase/deleteFirebaseCabinetTab.ts
+++ b/src/utils/firebase/deleteFirebaseCabinetTab.ts
@@ -1,0 +1,17 @@
+import { database } from '../../config/firebase.config';
+import customSwal from '../alert';
+import initializeFirebaseCabinetTab from './initializeFirebaseCabinetTab';
+
+export default function deleteFirebaseCabinetTab(cabinetNum: number) {
+  customSwal(
+    'warning',
+    '사물함 삭제 주의',
+    '탭에 해당되는 사물함 예약정보가 삭제되고 탭이 삭제됩니다. 정말 삭제하시겠습니까?',
+    true,
+  ).then((result) => {
+    if (result.isConfirmed) {
+      initializeFirebaseCabinetTab(cabinetNum);
+      database.ref(`cabinet/${cabinetNum}`).set(null);
+    }
+  });
+}

--- a/src/utils/firebase/initializeFirebaseCabinetTab.ts
+++ b/src/utils/firebase/initializeFirebaseCabinetTab.ts
@@ -1,0 +1,12 @@
+import { store } from '../../redux/store';
+import changeFirebaseCancelCabinetUser from './changeFirebaseCancelCabinetUser';
+
+export default function initializeFirebaseCabinetTab(cabinetNum: number) {
+  const getCabinetItem = store.getState().cabinet.cabinet?.[cabinetNum].item;
+  getCabinetItem?.map((item, index) => {
+    // 사물함 돌아다니며 예약되어 있는 사용자 아이디의 예약 정보 초기화
+    if (item.uuid) {
+      changeFirebaseCancelCabinetUser(cabinetNum, index, item.uuid);
+    }
+  });
+}


### PR DESCRIPTION
사물함 예약 취소 기능이 기존에 유저예약 정보만 취소해서 사물함정보도 같이 초기화 하게끔 바꿔놓았습니다.

사물함 삭제 기능을 추가하였습니다.


## 앞으로 할 일
이제 사물함 관리자 기능은 모두 끝이 났고 관리자 기능 ui 수정하고 메인페이지 사진 넣는 기능 시도해보도록 하겠습니다.
ps) 사물함 관리 기능은 pc에서만 하게하는 것은 어떨까요? 모바일에서 사물함관리를 수정하는 것 자체가 별로인 것 같기도 하네요.