### PR TITLE
V2/jong

### DIFF
--- a/src/Components/Cabinet/Cabinet.tsx
+++ b/src/Components/Cabinet/Cabinet.tsx
@@ -120,13 +120,18 @@ const CabinetTab = styled(Tab)({
   fontSize: `2vw`,
   letterSpacing: '0.1px',
   borderRadius: '10px',
-  fontFamily: 'Anton',
+  fontFamily: 'Anton,Noto Sans KR',
   minWidth: '20%',
   maxWidth: '100%',
-  padding: '2vh 0',
+  padding: '2vh 2vw',
 
   [`${media.medium}`]: {
     minWidth: '25%',
-    fontSize: '1.2rem',
+    fontSize: '1rem',
+    padding: '0 3vw',
+  },
+
+  [`${media.fold}`]: {
+    fontSize: '0.7rem',
   },
 });

--- a/src/Components/Cabinet/Cabinet.tsx
+++ b/src/Components/Cabinet/Cabinet.tsx
@@ -121,6 +121,7 @@ const CabinetTab = styled(Tab)({
   letterSpacing: '0.1px',
   borderRadius: '10px',
   fontFamily: 'Anton,Noto Sans KR',
+  fontWeight: 'bolder',
   minWidth: '20%',
   maxWidth: '100%',
   padding: '2vh 2vw',

--- a/src/Components/CabinetButtons/CabinetButtons.tsx
+++ b/src/Components/CabinetButtons/CabinetButtons.tsx
@@ -108,11 +108,11 @@ export default function CabinetButtons({
       typeof cabinetIdx === 'number'
     ) {
       target.blur();
-      if (cabinet)
+      if (cabinet && cabinetTitle)
         await Swal.fire({
           icon: 'error',
           title: '이미 신청한 사물함이 있습니다.',
-          text: `${cabinet[index].title}의 ${
+          text: `${cabinet[cabinetTitle].title}의 ${
             cabinetIdx + 1
           }번째 사물함의 신청을 취소하시겠습니까?`,
           showDenyButton: true,

--- a/src/Components/CabinetButtons/CabinetButtons.tsx
+++ b/src/Components/CabinetButtons/CabinetButtons.tsx
@@ -664,6 +664,11 @@ const CabinetStatusTooltip = styled(Tooltip)({
 
   [`${media.medium}`]: {
     flexGrow: 1,
+    fontSize: '0.9rem',
+  },
+
+  [`${media.fold}`]: {
+    fontSize: '0.7rem',
   },
 });
 
@@ -724,6 +729,10 @@ const AvailableCabinetButton = styled(Button)({
     borderRadius: '5px',
     border: '2px solid #00d145',
   },
+
+  [`${media.fold}`]: {
+    padding: '0.55rem',
+  },
 });
 
 const RegisteredCabinetButton = styled(Button)({
@@ -751,6 +760,10 @@ const RegisteredCabinetButton = styled(Button)({
     borderRadius: '5px',
     border: '2px solid lightgray',
   },
+
+  [`${media.fold}`]: {
+    padding: '0.55rem',
+  },
 });
 
 const BrokenCabinetButton = styled(Button)({
@@ -772,6 +785,10 @@ const BrokenCabinetButton = styled(Button)({
     fontSize: '0.5rem',
     borderRadius: '5px',
     border: '2px solid lightgray',
+  },
+
+  [`${media.fold}`]: {
+    padding: '0.55rem',
   },
 });
 
@@ -804,5 +821,9 @@ const MyCabinetButton = styled(Button)({
     fontSize: '0.5rem',
     borderRadius: '5px',
     border: '2px solid #008000',
+  },
+
+  [`${media.fold}`]: {
+    padding: '0.55rem',
   },
 });

--- a/src/index.css
+++ b/src/index.css
@@ -31,3 +31,14 @@ code {
 .swal2-container {
   z-index: 100000 !important;
 }
+
+@media (max-width: 768px) {
+  .swal2-title {
+    font-size: 1.2rem !important;
+  }
+
+  .swal2-popup {
+    font-size: 0.8rem !important;
+    width: 80vw !important;
+  }
+}

--- a/src/lib/styles/media.ts
+++ b/src/lib/styles/media.ts
@@ -8,7 +8,7 @@ const media = {
   medium: mediaQuery(1024),
   small: mediaQuery(768),
   xsmall: mediaQuery(375),
-  custom: mediaQuery,
+  fold: mediaQuery(280),
 };
 
 export default media;

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { styled } from '@material-ui/core/styles';
 import { Button, Container } from '@material-ui/core';
-import { useAppSelector, useUserSelector } from '../../redux/hooks';
+import {
+  useAppSelector,
+  useCabinetSelector,
+  useUserSelector,
+} from '../../redux/hooks';
 import Header from '../../Components/Header';
 import media from '../../lib/styles/media';
 import PasswordChangeForm from '../../Components/PasswordChangeForm';
@@ -10,7 +14,7 @@ export type UserPageProps = {};
 
 function UserPage({}: UserPageProps) {
   const { cabinetTitle, cabinetIdx } = useAppSelector(useUserSelector);
-
+  const { cabinet } = useAppSelector(useCabinetSelector);
   return (
     <PageContainer>
       <Header />
@@ -19,14 +23,10 @@ function UserPage({}: UserPageProps) {
           <UserPageTitle>나의 사물함</UserPageTitle>
           <MyCabinetContents>
             <MyCabinet>
-              {cabinetTitle ? (
-                `사물함위치 : ${
-                  cabinetTitle[
-                    // eslint-disable-next-line radix
-                    parseInt(cabinetTitle.substr(cabinetTitle.length - 1)) - 1
-                  ]
-                } -
-                    ${cabinetIdx}번 사물함`
+              {cabinetTitle && cabinetIdx && cabinet ? (
+                `${cabinet[cabinetTitle].title}
+                 -
+                    ${cabinetIdx + 1}번 사물함`
               ) : (
                 <NoCabinet>예약된 사물함이 없습니다.</NoCabinet>
               )}

--- a/src/redux/cabinet/cabinetSlice.ts
+++ b/src/redux/cabinet/cabinetSlice.ts
@@ -14,7 +14,7 @@ export type CabinetTabType = {
 export type CabinetItemType = {
   status: number;
   uuid?: string;
-  studentId?: string;
+  studentID?: string;
   name?: string;
 };
 

--- a/src/redux/user/userSlice.ts
+++ b/src/redux/user/userSlice.ts
@@ -4,7 +4,7 @@ export interface UserState {
   uuid: string | null;
   adminType: 0 | 1;
   cabinetIdx: number | null;
-  cabinetTitle: string;
+  cabinetTitle: number | null;
   name: string;
   studentID: string;
 }
@@ -21,7 +21,7 @@ export const userInitialState: UserState = {
   uuid: null,
   adminType: 0,
   cabinetIdx: null,
-  cabinetTitle: '',
+  cabinetTitle: null,
   name: '',
   studentID: '',
 };

--- a/src/utils/firebase/changeFirebaseCancelCabinetUser.ts
+++ b/src/utils/firebase/changeFirebaseCancelCabinetUser.ts
@@ -4,11 +4,11 @@ import { serverStatusType } from '../../redux/server/serverSlice';
 const changeFirebaseCancelCabinetUser = (
   cabinetNum: number,
   index: number,
-  uuid: string,
+  uuid: string | undefined | null,
 ) => {
   const postData = {
-    cabinetIdx: 0,
-    cabinetTitle: 0,
+    cabinetIdx: null,
+    cabinetTitle: null,
   };
   database.ref(`/cabinet/${cabinetNum}/item/${index}`).set({ status: 0 });
   return database.ref(`/users/${uuid}`).update(postData);


### PR DESCRIPTION
## 개발 사항

1. 모바일 UI 변경
- 사물함 탭에 padding 추가 
- 모바일 폰트와 글씨 크기 조정
- 갤럭시 폴드에서 사물함 크기 화면 벗어나는 문제 -> 폴드에 맞는 미디어쿼리 추가
- 모바일에서 swal 글씨 크기가 너무 커서 글씨크기를 줄였습니다

2. CabinetItemType의 `studentId`를 파이어베이스의 데이터의  `studentID`로 통일 시켰습니다

3. users 의 cabinetTitle 데이터를 사물함 title에서 탭 인덱스로 변경했습니다

4. 사물함 UI 변경
- 사물함 hover와 focus시 변화를 주어서 선택하는 느낌이 나도록 변경했습니다.
- hover와 focus의 변화가 없던 (고장난 사물함 등) 버튼에 효과를 추가했습니다.

5. `changeFirebaseCancelCabinetUser` 함수를 사용해서 관리자가 사용자 사물함을 취소하는 기능과 이미 신청했던 사물함을 취소하는 기능을 구현했습니다. 추가로 코드의 중복을 줄이고자 사물함 취소 함수를 `changeFirebaseCancelCabinetUser` 함수로 대체했습니다.

## 이후 할일

1. 서버상태에 따라 신청 막기
2. database 저장할 때 set대신 transaction 사용하기 (에러메시지도 추가)