### PR TITLE
database 함수(transaction)와 서버 상태에 따른 신청 기능 수정

### DIFF
--- a/src/Components/CabinetButtons/CabinetButtons.tsx
+++ b/src/Components/CabinetButtons/CabinetButtons.tsx
@@ -16,6 +16,7 @@ import {
   useAppSelector,
   useCabinetSelector,
   useUserSelector,
+  useServerSelector,
 } from '../../redux/hooks';
 import { setUserInfo } from '../../redux/user/userSlice';
 import { database } from '../../config/firebase.config';
@@ -44,6 +45,7 @@ export default function CabinetButtons({
   const [select, setSelect] = useState(-1);
   const [count, setCount] = useState([0, 0, 0]);
   const { cabinet } = useAppSelector(useCabinetSelector);
+  const { status } = useAppSelector(useServerSelector);
   const { uuid, adminType, studentID, name, cabinetIdx, cabinetTitle } =
     useAppSelector(useUserSelector);
   const cabinetRef = useRef<HTMLDivElement>(null);
@@ -55,6 +57,8 @@ export default function CabinetButtons({
 
   const showButtonText = () => {
     if (select === -1) {
+      if (adminType !== 1 && status === 1)
+        return '현재는 사물함 신청이 불가능합니다';
       return '사물함을 선택해주세요';
     }
 
@@ -227,7 +231,7 @@ export default function CabinetButtons({
         Swal.fire({
           icon: 'error',
           title: '사물함을 취소하시겠습니까?',
-          text: `유저의 사물함의 신청을 취소하시겠습니까?`,
+          text: `${item[select].name}님의 사물함을 취소하시겠습니까?`,
           showCancelButton: true,
           showConfirmButton: true,
           confirmButtonText: '네',
@@ -343,13 +347,17 @@ export default function CabinetButtons({
           onClick={(e) => {
             onClickCabinetButton(e, idx);
           }}
+          disabled={adminType !== 1 && status === 1}
         >
           {idx + 1}
         </AvailableCabinetButton>
       );
     } else if (item[idx].status === 1 && item[idx].uuid === uuid) {
       return (
-        <MyCabinetButton onClick={(e) => onClickCabinetButton(e, idx)}>
+        <MyCabinetButton
+          onClick={(e) => onClickCabinetButton(e, idx)}
+          disabled={adminType !== 1 && status === 1}
+        >
           {descriptionCabinet(idx)}
         </MyCabinetButton>
       );
@@ -473,7 +481,11 @@ export default function CabinetButtons({
       <CabinetButtonsContainer>{showGridRow()}</CabinetButtonsContainer>
       <CabinetSelectContainer>
         <SelectIdxContainer>
-          {select === -1 ? '-' : select + 1}
+          {adminType !== 1 && status === 1
+            ? null
+            : select === -1
+            ? '-'
+            : select + 1}
         </SelectIdxContainer>
         <SelectStatusContainer ref={submitRef}>
           <SelectButton onClick={onClickSubmitButton} disabled={select === -1}>

--- a/src/Components/CabinetButtons/CabinetButtons.tsx
+++ b/src/Components/CabinetButtons/CabinetButtons.tsx
@@ -79,8 +79,6 @@ export default function CabinetButtons({
     }
   };
 
-  const cancleCabinet = (title: string, idx: number) => {};
-
   const onClickCabinetButton = (e: React.MouseEvent, idx: number) => {
     const target = e.currentTarget as HTMLElement;
 

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -14,6 +14,7 @@ import MenuInfo from '../../Components/MenuInfo';
 import BackButton from '../../Components/BackButton';
 import { Redirect } from 'react-router';
 import CabinetManageModal from '../../Components/CabinetManageModal';
+import Swal from 'sweetalert2';
 
 export type AdminPageProps = {};
 
@@ -22,6 +23,54 @@ function AdminPage({}: AdminPageProps) {
   const { uuid } = useAppSelector(useUserSelector);
   const [total, setTotal] = useState(0);
   const [open, setOpen] = useState(false);
+
+  const onClickSeverStatusButton = () => {
+    if (status === 0) {
+      Swal.fire({
+        icon: 'warning',
+        title: '서버를 닫으시겠습니까?',
+        text: `서버를 닫게되면 유저들의 사물함 신청과 수정이 불가능해집니다.`,
+        showCancelButton: true,
+        showConfirmButton: true,
+        confirmButtonText: '네',
+        cancelButtonText: '아니요',
+        confirmButtonColor: 'rgb(63,81,181)',
+      }).then((result) => {
+        if (result.isConfirmed) {
+          changeFirebaseServerStatus(status);
+
+          Swal.fire({
+            icon: 'success',
+            title: '성공적으로 서버를 닫았습니다',
+            width: 'auto',
+            timer: 1500,
+          });
+        }
+      });
+    } else {
+      Swal.fire({
+        icon: 'warning',
+        title: '서버를 여시겠습니까?',
+        text: `서버를 열게되면 유저들의 사물함 신청과 수정이 가능해집니다.`,
+        showCancelButton: true,
+        showConfirmButton: true,
+        confirmButtonText: '네',
+        cancelButtonText: '아니요',
+        confirmButtonColor: 'rgb(63,81,181)',
+      }).then((result) => {
+        if (result.isConfirmed) {
+          changeFirebaseServerStatus(status);
+
+          Swal.fire({
+            icon: 'success',
+            title: '성공적으로 서버를 열었습니다',
+            width: 'auto',
+            timer: 1500,
+          });
+        }
+      });
+    }
+  };
 
   const handleOpen = () => {
     setOpen(true);
@@ -51,7 +100,7 @@ function AdminPage({}: AdminPageProps) {
         <AdminPageContents>
           <AdminPageTitle>관리자 기능</AdminPageTitle>
           <ButtonContainer>
-            <CancelButton onClick={() => changeFirebaseServerStatus(status)}>
+            <CancelButton onClick={onClickSeverStatusButton}>
               {status ? '서버 열기' : '서버 닫기'}
             </CancelButton>
             <CabinetManageButton onClick={handleOpen}>

--- a/src/utils/firebase/changeFirebaseCancelCabinetUser.ts
+++ b/src/utils/firebase/changeFirebaseCancelCabinetUser.ts
@@ -1,6 +1,8 @@
 import { database } from '../../config/firebase.config';
 import { serverStatusType } from '../../redux/server/serverSlice';
 
+const { default: Swal } = require('sweetalert2');
+
 const changeFirebaseCancelCabinetUser = (
   cabinetNum: number,
   index: number,
@@ -10,8 +12,47 @@ const changeFirebaseCancelCabinetUser = (
     cabinetIdx: null,
     cabinetTitle: null,
   };
-  database.ref(`/cabinet/${cabinetNum}/item/${index}`).set({ status: 0 });
-  return database.ref(`/users/${uuid}`).update(postData);
+
+  database.ref(`/cabinet/${cabinetNum}/item/${index}`).transaction(
+    (cabinet) => {
+      if (cabinet.uuid === uuid) {
+        return { status: 0 };
+      }
+
+      return;
+    },
+    (error, committed) => {
+      if (error) {
+        Swal.fire({
+          icon: 'error',
+          title: '사물함 취소 에러',
+          text: `관리자에게 문의해 주세요.`,
+          showConfirmButton: true,
+          width: 'auto',
+          timer: 2500,
+        });
+      } else if (!committed) {
+        Swal.fire({
+          icon: 'error',
+          title: '사물함 취소 실패',
+          text: `취소가 불가능합니다.`,
+          showConfirmButton: true,
+          width: 'auto',
+          timer: 2500,
+        });
+      } else {
+        Swal.fire({
+          icon: 'success',
+          title: '사물함 신청이 취소되었습니다',
+          width: 'auto',
+          showConfirmButton: true,
+          timer: 2000,
+        });
+
+        database.ref(`/users/${uuid}`).update(postData);
+      }
+    },
+  );
 };
 
 export default changeFirebaseCancelCabinetUser;


### PR DESCRIPTION
## 개발 사항
1. 서버가 닫히면 유저의 사물함 신청과 수정을 막는 기능을 추가했습니다.
2. 관리자페이지 서버 열기 / 서버 닫기 버튼에 swal 추가했습니다.
3. `set` 함수를 `transaction`으로 변경하고 코드 중복을 줄였습니다.

## 이후 해야할 일
1. database 관련 함수들 따로 분리하기