### PR TITLE
사물함 신청 기능 util 함수로 분리 / footer 컴포넌트 추가

### DIFF
--- a/src/Components/AppLayout/AppLayout.tsx
+++ b/src/Components/AppLayout/AppLayout.tsx
@@ -31,9 +31,11 @@ export default function AppLayout({
         <>
           <AppContainer>
             {children}
-            <FooterContainer>
-              <Footer />
-            </FooterContainer>
+            {footer ? (
+              <FooterContainer>
+                <Footer />
+              </FooterContainer>
+            ) : null}
           </AppContainer>
         </>
       )}

--- a/src/Components/AppLayout/AppLayout.tsx
+++ b/src/Components/AppLayout/AppLayout.tsx
@@ -1,21 +1,41 @@
 import { Container, styled } from '@material-ui/core';
 import React, { ReactElement } from 'react';
 import FadeIn from 'react-fade-in';
+import Footer from '../Footer';
 
 export type AppLayoutProps = {
   children: ReactElement | ReactElement[];
   fadeIn?: boolean | undefined;
+  footer?: boolean | undefined;
 };
 
-export default function AppLayout({ children, fadeIn }: AppLayoutProps) {
+export default function AppLayout({
+  children,
+  fadeIn,
+  footer,
+}: AppLayoutProps) {
   return (
     <>
-      {fadeIn === true ? (
-        <FadeIn delay={0} transitionDuration={500}>
-          <AppContainer>{children}</AppContainer>
-        </FadeIn>
+      {fadeIn ? (
+        <>
+          <FadeIn delay={0} transitionDuration={500}>
+            <AppContainer>{children}</AppContainer>
+          </FadeIn>
+          {footer ? (
+            <FooterContainer>
+              <Footer />
+            </FooterContainer>
+          ) : null}
+        </>
       ) : (
-        <AppContainer>{children}</AppContainer>
+        <>
+          <AppContainer>
+            {children}
+            <FooterContainer>
+              <Footer />
+            </FooterContainer>
+          </AppContainer>
+        </>
       )}
     </>
   );
@@ -25,6 +45,13 @@ const AppContainer = styled(Container)({
   display: 'flex',
   alignItems: 'center',
   flexDirection: 'column',
+  width: '100%',
+  height: '100vh',
+});
+
+const FooterContainer = styled(Container)({
+  display: 'flex',
+  justifyContent: 'center',
   width: '100%',
   height: '100vh',
 });

--- a/src/Components/CabinetButtons/CabinetButtons.tsx
+++ b/src/Components/CabinetButtons/CabinetButtons.tsx
@@ -19,9 +19,9 @@ import {
   useServerSelector,
 } from '../../redux/hooks';
 import { setUserInfo } from '../../redux/user/userSlice';
-import { database } from '../../config/firebase.config';
 import media from '../../lib/styles/media';
 import changeCabinetStatus from '../../utils/firebase/changeCabinetStatus';
+import applyForCabinet from '../../utils/firebase/applyForCabinet';
 import AppLayout from '../AppLayout';
 import Swal from 'sweetalert2';
 import customSwal from '../../utils/alert';
@@ -135,67 +135,31 @@ export default function CabinetButtons({
             confirmButtonColor: 'rgb(63,81,181)',
           }).then((result) => {
             if (result.isConfirmed) {
-              database.ref(`cabinet/${index}/item/${select}`).transaction(
-                (cabinet) => {
-                  if (cabinet.status === 0) {
-                    return {
-                      status: 1,
-                      uuid: uuid,
-                      studentID: studentID,
-                      name: name,
-                    };
-                  }
+              if (uuid && name && studentID)
+                applyForCabinet(index, select, {
+                  status: 1,
+                  uuid,
+                  name,
+                  studentID,
+                });
 
-                  return;
-                },
-                (error, committed, snapshot) => {
-                  if (error) {
-                    Swal.fire({
-                      icon: 'error',
-                      title: '사물함 신청 에러',
-                      text: `관리자에게 문의해 주세요.`,
-                      showConfirmButton: true,
-                      width: 'auto',
-                      timer: 5000,
-                    });
-                  } else if (!committed) {
-                    Swal.fire({
-                      icon: 'error',
-                      title: '사물함 신청 실패',
-                      text: `이미 신청한 사람이 있거나 신청이 불가능합니다.`,
-                      showConfirmButton: true,
-                      width: 'auto',
-                      timer: 5000,
-                    });
-                  } else {
-                    database.ref(`users/${uuid}`).set({
-                      adminType: adminType,
-                      cabinetIdx: select,
-                      cabinetTitle: index,
-                      name: name,
-                      studentID: studentID,
-                    });
-
-                    dispatch(
-                      setUserInfo({
-                        adminType: 0,
-                        cabinetIdx: select,
-                        cabinetTitle: index,
-                        name: name,
-                        studentID: studentID,
-                      }),
-                    );
-
-                    Swal.fire({
-                      icon: 'success',
-                      title: '사물함이 신청되었습니다.',
-                      width: 'auto',
-                      showConfirmButton: true,
-                      timer: 2000,
-                    });
-                  }
-                },
+              dispatch(
+                setUserInfo({
+                  adminType: 0,
+                  cabinetIdx: select,
+                  cabinetTitle: index,
+                  name: name,
+                  studentID: studentID,
+                }),
               );
+
+              Swal.fire({
+                icon: 'success',
+                title: '사물함이 신청되었습니다.',
+                width: 'auto',
+                showConfirmButton: true,
+                timer: 2000,
+              });
             } else {
               setSelect(select);
             }

--- a/src/Components/CabinetButtons/CabinetButtons.tsx
+++ b/src/Components/CabinetButtons/CabinetButtons.tsx
@@ -59,7 +59,7 @@ export default function CabinetButtons({
   const showButtonText = () => {
     if (select === -1) {
       if (adminType !== 1 && status === 1)
-        return '현재는 사물함 신청이 불가능합니다';
+        return '서버가 닫혀있으므로 현재는 사물함 신청이 불가능합니다';
       return '사물함을 선택해주세요';
     }
 
@@ -695,11 +695,14 @@ const SelectButton = styled(Button)({
   },
 
   [`${media.medium}`]: {
-    padding: '0.5vh 5vw',
+    padding: '2vh 5vw',
+    minHeight: '30px',
     width: 'auto',
 
     '&:disabled': {
       fontSize: '0.4rem',
+      textAlign: 'center',
+      width: '80vw',
     },
   },
 });
@@ -725,7 +728,7 @@ const AvailableCabinetButton = styled(Button)({
   },
 
   [`${media.medium}`]: {
-    padding: '0.6rem',
+    padding: '0.7rem',
     margin: '0.5vh 0.7vw',
     minWidth: '1.5vw',
     outline: 'none',
@@ -744,6 +747,10 @@ const AvailableCabinetButton = styled(Button)({
       border: '2px solid #03bd41',
       color: 'white',
     },
+  },
+
+  [`${media.se}`]: {
+    padding: '0.6rem',
   },
 
   [`${media.fold}`]: {
@@ -775,7 +782,7 @@ const RegisteredCabinetButton = styled(Button)({
   },
 
   [`${media.medium}`]: {
-    padding: '0.6rem',
+    padding: '0.7rem',
     margin: '0.5vh 0.7vw',
     minWidth: '1.5vw',
     outline: 'none',
@@ -795,6 +802,10 @@ const RegisteredCabinetButton = styled(Button)({
       border: '2px solid #3d3d3d',
       color: 'white',
     },
+  },
+
+  [`${media.se}`]: {
+    padding: '0.6rem',
   },
 
   [`${media.fold}`]: {
@@ -825,7 +836,7 @@ const BrokenCabinetButton = styled(Button)({
   },
 
   [`${media.medium}`]: {
-    padding: '0.6rem',
+    padding: '0.7rem',
     margin: '0.5vh 0.7vw',
     minWidth: '1.5vw',
     outline: 'none',
@@ -845,6 +856,10 @@ const BrokenCabinetButton = styled(Button)({
       border: '2px solid #eeb004',
       color: 'white',
     },
+  },
+
+  [`${media.se}`]: {
+    padding: '0.6rem',
   },
 
   [`${media.fold}`]: {
@@ -874,7 +889,7 @@ const MyCabinetButton = styled(Button)({
   },
 
   [`${media.medium}`]: {
-    padding: '0.6rem',
+    padding: '0.7rem',
     margin: '0.5vh 0.7vw',
     minWidth: '1.5vw',
     maxHeight: '1.5vw',
@@ -893,6 +908,10 @@ const MyCabinetButton = styled(Button)({
       color: 'white',
       border: '2px solid #DF1840',
     },
+  },
+
+  [`${media.se}`]: {
+    padding: '0.6rem',
   },
 
   [`${media.fold}`]: {

--- a/src/Components/CabinetButtons/CabinetButtons.tsx
+++ b/src/Components/CabinetButtons/CabinetButtons.tsx
@@ -105,7 +105,6 @@ export default function CabinetButtons({
           if (result.isDenied) {
             if (cabinetTitle)
               changeFirebaseCancelCabinetUser(cabinetTitle, cabinetIdx, uuid);
-
             setSelect(idx);
 
             return setTimeout(() => target.focus(), 300);
@@ -142,24 +141,6 @@ export default function CabinetButtons({
                   name,
                   studentID,
                 });
-
-              dispatch(
-                setUserInfo({
-                  adminType: 0,
-                  cabinetIdx: select,
-                  cabinetTitle: index,
-                  name: name,
-                  studentID: studentID,
-                }),
-              );
-
-              Swal.fire({
-                icon: 'success',
-                title: '사물함이 신청되었습니다.',
-                width: 'auto',
-                showConfirmButton: true,
-                timer: 2000,
-              });
             } else {
               setSelect(select);
             }
@@ -197,14 +178,6 @@ export default function CabinetButtons({
         }).then((result) => {
           if (result.isConfirmed) {
             changeCabinetStatus(index, select, 2);
-
-            Swal.fire({
-              icon: 'success',
-              title: '사물함 상태가 변경되었습니다',
-              width: 'auto',
-              showConfirmButton: true,
-              timer: 2000,
-            });
           }
         });
       } else if (item[select].status === 1) {
@@ -235,14 +208,6 @@ export default function CabinetButtons({
         }).then((result) => {
           if (result.isConfirmed) {
             changeCabinetStatus(index, select, 0);
-
-            Swal.fire({
-              icon: 'success',
-              title: '사물함 상태가 변경되었습니다',
-              width: 'auto',
-              showConfirmButton: true,
-              timer: 2000,
-            });
           }
         });
       }

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -1,0 +1,44 @@
+import { styled } from '@material-ui/core';
+import media from '../../lib/styles/media';
+
+export default function Footer() {
+  return (
+    <FooterContainer>
+      Currently v2, © 2021.
+      <LinkToProfile href="https://github.com/Kyun2da" target="_blank">
+        Kyun2da
+      </LinkToProfile>
+      ,
+      <LinkToProfile href="https://github.com/Jongminfire" target="_blank">
+        Jongminfire
+      </LinkToProfile>
+    </FooterContainer>
+  );
+}
+
+const FooterContainer = styled('p')({
+  color: 'lightgray',
+  position: 'absolute',
+  bottom: 10,
+
+  [`${media.xsmall}`]: {
+    fontSize: '4vw',
+  },
+});
+
+const LinkToProfile = styled('a')({
+  textDecoration: 'none',
+  color: 'lightgray',
+  transition: 'all 0.5s ease-in-out',
+  marginLeft: '0.3vw',
+
+  '&:hover': {
+    color: '#757575',
+  },
+
+  [`${media.medium}`]: {
+    '&:hover': {
+      color: 'lightgray',
+    },
+  },
+});

--- a/src/Components/Footer/index.tsx
+++ b/src/Components/Footer/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Footer';

--- a/src/lib/styles/media.ts
+++ b/src/lib/styles/media.ts
@@ -8,7 +8,8 @@ const media = {
   medium: mediaQuery(1024),
   small: mediaQuery(768),
   xsmall: mediaQuery(375),
-  fold: mediaQuery(280),
+  se: mediaQuery(340),
+  fold: mediaQuery(295),
 };
 
 export default media;

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -124,6 +124,9 @@ const PageContainer = styled(Container)({
   flexDirection: 'column',
   minWidth: '100%',
   height: '100vh',
+  marginBottom: '7vh',
+
+  [`${media.medium}`]: { marginBottom: '0' },
 });
 
 const AdminPageContainer = styled(Container)({

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -52,7 +52,7 @@ function Login({}: LoginProps) {
   }
 
   return (
-    <AppLayout fadeIn>
+    <AppLayout fadeIn footer>
       <LogoImg src={Logo} alt="logo" />
       <LogoTitle>SEJONG UNIV</LogoTitle>
       <LogoTitle2>소프트웨어학과 사물함</LogoTitle2>

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -35,7 +35,7 @@ function MainPage({}: MainPageProps) {
   });
 
   return (
-    <AppLayout>
+    <AppLayout footer>
       <Header>
         {isMobile ? null : (
           <div>

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -35,7 +35,7 @@ function MainPage({}: MainPageProps) {
   });
 
   return (
-    <AppLayout footer>
+    <AppLayout>
       <Header>
         {isMobile ? null : (
           <div>

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -74,7 +74,7 @@ function SignUp({}: SignUpProps) {
   }
 
   return (
-    <AppLayout fadeIn>
+    <AppLayout fadeIn footer>
       <LogoContainer>
         <LogoImg src={Logo} alt="logo" />
         <LogoTitle>SEJONG UNIV</LogoTitle>

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -49,6 +49,9 @@ const PageContainer = styled(Container)({
   flexDirection: 'column',
   minWidth: '100%',
   height: '100vh',
+  marginBottom: '7vh',
+
+  [`${media.medium}`]: { marginBottom: '0' },
 });
 
 const UserPageContainer = styled(Container)({

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -49,7 +49,6 @@ const PageContainer = styled(Container)({
   flexDirection: 'column',
   minWidth: '100%',
   height: '100vh',
-  marginBottom: '7vh',
 
   [`${media.medium}`]: { marginBottom: '0' },
 });

--- a/src/redux/cabinet/cabinetSlice.ts
+++ b/src/redux/cabinet/cabinetSlice.ts
@@ -13,9 +13,9 @@ export type CabinetTabType = {
 
 export type CabinetItemType = {
   status: number;
-  uuid?: string;
-  studentID?: string;
-  name?: string;
+  uuid?: string | undefined;
+  studentID?: string | undefined;
+  name?: string | undefined;
 };
 
 const initialState: CabinetType = {

--- a/src/utils/firebase/applyForCabinet.ts
+++ b/src/utils/firebase/applyForCabinet.ts
@@ -1,0 +1,55 @@
+import { database } from '../../config/firebase.config';
+import Swal from 'sweetalert2';
+import type { CabinetItemType } from '../../redux/cabinet/cabinetSlice';
+
+const applyForCabinet = (
+  cabinetIndex: number,
+  selectedCabinet: number,
+  { status, uuid, name, studentID }: CabinetItemType,
+) => {
+  database.ref(`cabinet/${cabinetIndex}/item/${selectedCabinet}`).transaction(
+    (cabinet) => {
+      if (cabinet.status === 0) {
+        return {
+          status: status,
+          uuid: uuid,
+          studentID: studentID,
+          name: name,
+        };
+      }
+
+      return;
+    },
+    (error, committed, snapshot) => {
+      if (error) {
+        Swal.fire({
+          icon: 'error',
+          title: '사물함 신청 에러',
+          text: `관리자에게 문의해 주세요.`,
+          showConfirmButton: true,
+          width: 'auto',
+          timer: 5000,
+        });
+      } else if (!committed) {
+        Swal.fire({
+          icon: 'error',
+          title: '사물함 신청 실패',
+          text: `이미 신청한 사람이 있거나 신청이 불가능합니다.`,
+          showConfirmButton: true,
+          width: 'auto',
+          timer: 5000,
+        });
+      } else {
+        database.ref(`users/${uuid}`).set({
+          adminType: 0,
+          cabinetIdx: selectedCabinet,
+          cabinetTitle: cabinetIndex,
+          name: name,
+          studentID: studentID,
+        });
+      }
+    },
+  );
+};
+
+export default applyForCabinet;

--- a/src/utils/firebase/applyForCabinet.ts
+++ b/src/utils/firebase/applyForCabinet.ts
@@ -47,6 +47,14 @@ const applyForCabinet = (
           name: name,
           studentID: studentID,
         });
+
+        Swal.fire({
+          icon: 'success',
+          title: '사물함이 신청되었습니다.',
+          width: 'auto',
+          showConfirmButton: true,
+          timer: 2000,
+        });
       }
     },
   );

--- a/src/utils/firebase/changeCabinetStatus.ts
+++ b/src/utils/firebase/changeCabinetStatus.ts
@@ -1,4 +1,5 @@
 import { database } from '../../config/firebase.config';
+import Swal from 'sweetalert2';
 
 const changeCabinetStatus = (
   cabinetIndex: number,
@@ -7,6 +8,14 @@ const changeCabinetStatus = (
 ) => {
   database.ref(`cabinet/${cabinetIndex}/item/${selectedCabinet}`).set({
     status: changeStatus,
+  });
+
+  Swal.fire({
+    icon: 'success',
+    title: '사물함 상태가 변경되었습니다',
+    width: 'auto',
+    showConfirmButton: true,
+    timer: 2000,
   });
 };
 


### PR DESCRIPTION
## 개발 사항

1. 사물함 신청 기능을 util 함수로 분리했습니다.
2. footer 컴포넌트를 추가해서 `appLayout`에서 불러오도록 했습니다.  appLayout에서 `footer` 인자를 추가하면 페이지에 footer를 넣을 수 있습니다. ( position:'absolute' 라서 스크롤이 생길 수 있는 페이지에서는 사용이 불가능합니다)

## 이후 할일

1. cabinetButton에서 사물함 관련 함수를 util 폴더에 분리하긴 했는데 swal 메세지가 아직 많이 차지 하는 것 같아서 swal 메세지까지 따로 분리 해보겠습니다