### PR TITLE
firebase storage와 연동하여 사진 등록기능 및 메인페이지에서 보여주는 기능 추가

### DIFF
--- a/src/Components/Cabinet/Cabinet.tsx
+++ b/src/Components/Cabinet/Cabinet.tsx
@@ -11,10 +11,12 @@ import type {
   CabinetItemType,
 } from '../../redux/cabinet/cabinetSlice';
 
-export type CabinetProps = {};
+export type CabinetProps = {
+  index: number;
+  setIndex: React.Dispatch<React.SetStateAction<number>>;
+};
 
-export default function Cabinet({}: CabinetProps) {
-  const [index, setIndex] = useState(0);
+export default function Cabinet({ index, setIndex }: CabinetProps) {
   const { cabinet } = useAppSelector(useCabinetSelector);
 
   const handleChangeIndex = (value: number) => {

--- a/src/Components/CabinetManageEnrollPhoto/CabinetManageEnrollPhoto.tsx
+++ b/src/Components/CabinetManageEnrollPhoto/CabinetManageEnrollPhoto.tsx
@@ -3,32 +3,83 @@ import {
   Card,
   CardActions,
   CardContent,
+  CardHeader,
   CardMedia,
+  Input,
   styled,
   Typography,
 } from '@material-ui/core';
+import { useEffect, useState } from 'react';
+import { storage } from '../../config/firebase.config';
+import useDownloadURL from '../../hooks/useDownloadURL';
 
 type CabinetEnrollPhotoCardProps = {
   image: string | undefined;
   photoType: 'position' | 'real';
+  index: number;
 };
 
 export default function CabinetEnrollPhotoCard({
   image,
   photoType,
+  index,
 }: CabinetEnrollPhotoCardProps) {
+  const [url, setUrl] = useState('');
+  const handleChange = (e: any) => {
+    console.log(index, photoType);
+    const uploadTask = storage
+      .ref(`/${index}/${photoType}`)
+      .put(e.currentTarget.files[0]);
+    uploadTask.on(
+      'state_changed',
+      (snapshot) => {},
+      (error) => {
+        console.error(error);
+      },
+      () => {
+        storage
+          .ref(`/${index}/${photoType}`)
+          .getDownloadURL()
+          .then((url) => {
+            console.log(url);
+            setUrl(url);
+          });
+      },
+    );
+  };
+
+  useEffect(() => {
+    storage
+      .ref(`/${index}/${photoType}`)
+      .getDownloadURL()
+      .then((url) => {
+        console.log(url);
+        setUrl(url);
+      });
+  }, []);
   return (
     <CustomCard>
-      <CustomCardMedia image={image} title="사물함 이미지" />
-      <CardContent>
-        <CustomTypography gutterBottom variant="h5">
-          {photoType === 'position' ? '사물함 위치 사진' : '사물함 실물 사진'}
-        </CustomTypography>
-      </CardContent>
+      <CustomCardHeader
+        title={
+          photoType === 'position' ? '사물함 위치 사진' : '사물함 실물 사진'
+        }
+      ></CustomCardHeader>
+      <ImageContainer>
+        <CustomImage src={url || image}></CustomImage>
+      </ImageContainer>
       <CustomCardActions>
-        <Button size="small" color="primary">
-          사진 등록하기
-        </Button>
+        <PhotoInput
+          accept="image/*"
+          id={`${index}/${photoType}`}
+          multiple
+          type="file"
+          onChange={handleChange}
+        />
+        <label htmlFor={`${index}/${photoType}`}>
+          <Button color="primary" component="span">
+            등록하기
+          </Button>
+        </label>
       </CustomCardActions>
     </CustomCard>
   );
@@ -39,14 +90,27 @@ const CustomCard = styled(Card)({
   margin: '0 24px',
 });
 
-const CustomTypography = styled(Typography)({
+const ImageContainer = styled('div')({
+  width: 'auto',
   textAlign: 'center',
 });
 
-const CustomCardMedia = styled(CardMedia)({
-  height: '240px',
+const CustomImage = styled('img')({
+  maxWidth: '100%',
+  height: '320px',
+  margin: '16px',
 });
 
 const CustomCardActions = styled(CardActions)({
   justifyContent: 'flex-end',
+});
+
+const PhotoInput = styled('input')({
+  display: 'none',
+});
+
+const CustomCardHeader = styled(CardHeader)({
+  textAlign: 'center',
+  color: 'white',
+  backgroundColor: 'black',
 });

--- a/src/Components/CabinetManageItem/CabinetManageItem.tsx
+++ b/src/Components/CabinetManageItem/CabinetManageItem.tsx
@@ -67,8 +67,13 @@ export default function CabinetManageItem({
           <CabinetEnrollPhotoCard
             image={cabinetNoImage2}
             photoType="position"
+            index={index}
           />
-          <CabinetEnrollPhotoCard image={cabinetNoImage1} photoType="real" />
+          <CabinetEnrollPhotoCard
+            image={cabinetNoImage1}
+            photoType="real"
+            index={index}
+          />
         </CabinetPhotoContainer>
         <Divider />
         <TextFieldContainer>

--- a/src/Components/PhotoSwiper/PhotoSwiper.tsx
+++ b/src/Components/PhotoSwiper/PhotoSwiper.tsx
@@ -1,11 +1,40 @@
 import { SwipeableDrawer } from '@material-ui/core';
+import { useEffect, useState } from 'react';
+import { storage } from '../../config/firebase.config';
+import useDownloadURL from '../../hooks/useDownloadURL';
+import cabinetNoImage1 from '../../images/cabinetNoImage1.png';
+import cabinetNoImage2 from '../../images/cabinetNoImage2.png';
+import { useAppSelector, useCabinetSelector } from '../../redux/hooks';
 
 type PhotoSwiperProps = {
   open: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  index: number;
 };
 
-export default function PhotoSwiper({ open, setOpen }: PhotoSwiperProps) {
+export default function PhotoSwiper({
+  open,
+  setOpen,
+  index,
+}: PhotoSwiperProps) {
+  const { cabinet } = useAppSelector(useCabinetSelector);
+  const [url1, setUrl1] = useState('');
+  const [url2, setUrl2] = useState('');
+
+  useEffect(() => {
+    const idxArr: number[] = [];
+    cabinet?.map((item, index: number) => idxArr.push(index));
+    storage
+      .ref(`/${idxArr[index]}/position`)
+      .getDownloadURL()
+      .then((url: string) => setUrl1(url))
+      .catch((e) => setUrl1(''));
+    storage
+      .ref(`/${idxArr[index]}/real`)
+      .getDownloadURL()
+      .then((url: string) => setUrl2(url))
+      .catch((e) => setUrl2(''));
+  }, [index]);
   return (
     <SwipeableDrawer
       anchor="top"
@@ -26,13 +55,13 @@ export default function PhotoSwiper({ open, setOpen }: PhotoSwiperProps) {
         }}
       >
         <img
-          // src={mapImage}
+          src={url1 || cabinetNoImage2}
           alt="map"
           width="50%"
           style={{ backgroundColor: 'white' }}
         />
         <img
-          // src={cabinetImage}
+          src={url2 || cabinetNoImage1}
           alt="cabinetpicture"
           width="30%"
           style={{ padding: '1rem', backgroundColor: 'white' }}

--- a/src/config/firebase.config.ts
+++ b/src/config/firebase.config.ts
@@ -1,6 +1,7 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/database';
+import 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_APIKEY,
@@ -17,5 +18,6 @@ firebase.initializeApp(firebaseConfig);
 
 export const auth = firebase.auth();
 export const database = firebase.database();
+export const storage = firebase.storage();
 
 export default firebase;

--- a/src/hooks/useDownloadURL.ts
+++ b/src/hooks/useDownloadURL.ts
@@ -1,0 +1,34 @@
+import firebase from 'firebase/app';
+import { useEffect } from 'react';
+import { useComparatorRef } from './refHooks';
+import useLoadingValue from './useLoadingValue';
+import { LoadingHook } from './useObject';
+
+export type DownloadURLHook = LoadingHook<string, firebase.FirebaseError>;
+
+export default (
+  storageRef?: firebase.storage.Reference | null,
+): DownloadURLHook => {
+  const { error, loading, reset, setError, setValue, value } =
+    useLoadingValue<string, firebase.FirebaseError>();
+  const ref = useComparatorRef(storageRef, isEqual, reset);
+
+  useEffect(() => {
+    if (!ref.current) {
+      setValue(undefined);
+      return;
+    }
+    ref.current.getDownloadURL().then(setValue).catch(setError);
+  }, [ref.current]);
+
+  return [value, loading, error];
+};
+
+const isEqual = (
+  v1: firebase.storage.Reference | null | undefined,
+  v2: firebase.storage.Reference | null | undefined,
+): boolean => {
+  const bothNull: boolean = !v1 && !v2;
+  const equal: boolean = !!v1 && !!v2 && v1.fullPath === v2.fullPath;
+  return bothNull || equal;
+};

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Header from '../../Components/Header';
 import HelperButton from '../../Components/HelperButton';
 import HelperModal from '../../Components/HelperModal';
@@ -18,10 +18,14 @@ function MainPage({}: MainPageProps) {
   const [openModal, setOpenModal] = useState<boolean>(false);
   const [openSwiperPhoto, setOpenSwiperPhoto] = useState<boolean>(false);
   const { uuid } = useAppSelector(useUserSelector);
+  const [index, setIndex] = useState(0);
   const handleOpen = () => {
     setOpenModal((tmp) => !tmp);
   };
 
+  useEffect(() => {
+    console.log(index);
+  }, [index]);
   const showPhoto = () => {
     setOpenSwiperPhoto((tmp) => !tmp);
   };
@@ -46,9 +50,13 @@ function MainPage({}: MainPageProps) {
         <PhotoShowButton onClick={showPhoto} />
         <MenuInfo openHelpModal={handleOpen} />
       </Header>
-      <Cabinet />
+      <Cabinet index={index} setIndex={setIndex} />
       <HelperModal open={openModal} setOpen={handleOpen} />
-      <PhotoSwiper open={openSwiperPhoto} setOpen={setOpenSwiperPhoto} />
+      <PhotoSwiper
+        open={openSwiperPhoto}
+        setOpen={setOpenSwiperPhoto}
+        index={index}
+      />
     </AppLayout>
   );
 }


### PR DESCRIPTION
사진 등록 및 메인페이지에서 보여주는 기능을 추가하였습니다.

- 관리자 페이지 말씀하신대로 ui 살짝 수정해보았습니다. 두개의 사진의 height가 다른경우에 height max를 지정해놓으면 원하는 것처럼 이쁘게 보이지는 않는 것 같아 적당하게 사진 크기를 고정하는 식으로 하였습니다.


## 해야할 기능

- 사물함 삭제시 storage의 등록된 사진도 같이 삭제되게끔 하기
