### PR TITLE
헤더 로그아웃 버그 임시 해결 및 UI 수정

### DIFF
--- a/src/Components/Cabinet/Cabinet.tsx
+++ b/src/Components/Cabinet/Cabinet.tsx
@@ -107,14 +107,16 @@ const CabinetSwipeableViews = styled(SwipeableViews)({
   marginTop: '3.5vh',
   border: '0.5vh solid lightgray',
   borderRadius: '2vw',
-  padding: '2vh 0 4vh',
+  padding: '2vh 0 3vh',
   overflow: 'hidden',
   marginBottom: '2vh',
+  minHeight: '70%',
 
   [`${media.medium}`]: {
     border: 'none',
     marginTop: '0',
     padding: '2vh 0',
+    minHeight: 'auto',
   },
 });
 
@@ -125,7 +127,7 @@ const CabinetTab = styled(Tab)({
   fontFamily: 'Anton,Noto Sans KR',
   minWidth: '20%',
   maxWidth: '100%',
-  padding: '2vh 2vw',
+  padding: '1.5vh 2vw',
 
   [`${media.medium}`]: {
     minWidth: '25%',

--- a/src/Components/CabinetContents/CabinetContents.tsx
+++ b/src/Components/CabinetContents/CabinetContents.tsx
@@ -490,7 +490,7 @@ const SelectStatusContainer = styled('div')({
   fontSize: '3vw',
   justifyContent: 'flex-end',
   marginRight: '3vw',
-  marginTop: '2vh',
+  marginTop: '1vh',
 
   [`${media.medium}`]: {
     fontSize: '1.5rem',

--- a/src/Components/CabinetManageAddItem/CabinetManageAddItem.tsx
+++ b/src/Components/CabinetManageAddItem/CabinetManageAddItem.tsx
@@ -87,7 +87,8 @@ export default function CabinetManageAddItem({}: CabinetManageAddItemProps) {
 
 const AddCabinetForm = styled('form')({
   display: 'flex',
-  justifyContent: 'space-evenly',
+  // justifyContent: 'space-evenly',
+  columnGap: '2.5vw',
 });
 
 const CabinetAddTextField = styled(TextField)({

--- a/src/Components/CabinetManageEnrollPhoto/CabinetManageEnrollPhoto.tsx
+++ b/src/Components/CabinetManageEnrollPhoto/CabinetManageEnrollPhoto.tsx
@@ -61,7 +61,9 @@ export default function CabinetEnrollPhotoCard({
     <CustomCard>
       <CustomCardHeader
         title={
-          photoType === 'position' ? '사물함 위치 사진' : '사물함 실물 사진'
+          <TitleTypography>
+            {photoType === 'position' ? '사물함 위치 사진' : '사물함 실물 사진'}
+          </TitleTypography>
         }
       ></CustomCardHeader>
       <ImageContainer>
@@ -113,4 +115,9 @@ const CustomCardHeader = styled(CardHeader)({
   textAlign: 'center',
   color: 'white',
   backgroundColor: 'black',
+});
+
+const TitleTypography = styled(Typography)({
+  fontFamily: 'Noto Sans KR',
+  fontSize: '1.2rem',
 });

--- a/src/Components/CabinetManageItem/CabinetManageItem.tsx
+++ b/src/Components/CabinetManageItem/CabinetManageItem.tsx
@@ -54,79 +54,84 @@ export default function CabinetManageItem({
     deleteFirebaseCabinetTab(index);
   };
   return (
-    <Accordion>
-      <AccordionSummary
-        expandIcon={<ExpandMoreIcon />}
-        aria-controls="panel1c-content"
-        id="panel1c-header"
-      >
-        <Typography>{item.title}</Typography>
-      </AccordionSummary>
-      <AccordionDetailsContainer>
-        <CabinetPhotoContainer>
-          <CabinetEnrollPhotoCard
-            image={cabinetNoImage2}
-            photoType="position"
-            index={index}
-          />
-          <CabinetEnrollPhotoCard
-            image={cabinetNoImage1}
-            photoType="real"
-            index={index}
-          />
-        </CabinetPhotoContainer>
-        <Divider />
-        <TextFieldContainer>
-          <TextField
-            label="제목"
-            defaultValue={title}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setTitle(e.target.value);
-            }}
-            helperText="변경하고자 하는 제목을 입력해주세요."
-            variant="outlined"
-          />
-          <TextField
-            label="가로"
-            defaultValue={width}
-            type="number"
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setWidth(parseInt(e.target.value));
-            }}
-            helperText="변경하고자 하는 가로를 입력해주세요."
-            variant="outlined"
-          />
-          <TextField
-            label="세로"
-            defaultValue={height}
-            type="number"
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setHeight(parseInt(e.target.value));
-            }}
-            helperText="변경하고자 하는 세로를 입력해주세요."
-            variant="outlined"
-          />
-        </TextFieldContainer>
-      </AccordionDetailsContainer>
-      <Divider />
-      <AccordionActions>
-        <Button
-          size="small"
-          style={{ color: 'red' }}
-          onClick={handleInitialize}
+    <CabinetManageItemContainer>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel1c-content"
+          id="panel1c-header"
         >
-          해당 탭의 사물함 초기화하기
-        </Button>
-        <Button size="small" style={{ color: 'red' }} onClick={handleDelete}>
-          삭제하기
-        </Button>
-        <Button size="small" color="primary" onClick={handleSubmit}>
-          저장하기
-        </Button>
-      </AccordionActions>
-    </Accordion>
+          <TitleTypography>{item.title}</TitleTypography>
+        </AccordionSummary>
+        <TitleDivider />
+        <AccordionDetailsContainer>
+          <CabinetPhotoContainer>
+            <CabinetEnrollPhotoCard
+              image={cabinetNoImage2}
+              photoType="position"
+              index={index}
+            />
+            <CabinetEnrollPhotoCard
+              image={cabinetNoImage1}
+              photoType="real"
+              index={index}
+            />
+          </CabinetPhotoContainer>
+          <CustomDivider />
+          <TextFieldContainer>
+            <TextField
+              label="제목"
+              defaultValue={title}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setTitle(e.target.value);
+              }}
+              helperText="변경하고자 하는 제목을 입력해주세요."
+              variant="outlined"
+            />
+            <TextField
+              label="가로"
+              defaultValue={width}
+              type="number"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setWidth(parseInt(e.target.value));
+              }}
+              helperText="변경하고자 하는 가로를 입력해주세요."
+              variant="outlined"
+            />
+            <TextField
+              label="세로"
+              defaultValue={height}
+              type="number"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setHeight(parseInt(e.target.value));
+              }}
+              helperText="변경하고자 하는 세로를 입력해주세요."
+              variant="outlined"
+            />
+          </TextFieldContainer>
+        </AccordionDetailsContainer>
+        <Divider />
+        <AccordionActions>
+          <Button
+            size="small"
+            style={{ color: 'red' }}
+            onClick={handleInitialize}
+          >
+            해당 탭의 사물함 초기화하기
+          </Button>
+          <Button size="small" style={{ color: 'red' }} onClick={handleDelete}>
+            삭제하기
+          </Button>
+          <Button size="small" color="primary" onClick={handleSubmit}>
+            저장하기
+          </Button>
+        </AccordionActions>
+      </Accordion>
+    </CabinetManageItemContainer>
   );
 }
+
+const CabinetManageItemContainer = styled('div')({ marginBottom: '15px' });
 
 const AccordionDetailsContainer = styled(AccordionDetails)({
   justifyContent: 'space-evenly',
@@ -143,4 +148,18 @@ const TextFieldContainer = styled('div')({
   display: 'flex',
   // justifyContent: 'space-evenly',
   columnGap: '2.5vw',
+  marginLeft: '1.2vw',
+});
+
+const TitleTypography = styled(Typography)({
+  fontFamily: 'Anton,Noto Sans KR',
+  fontSize: '1.2rem',
+});
+
+const CustomDivider = styled(Divider)({
+  margin: '2vh 0',
+});
+
+const TitleDivider = styled(Divider)({
+  marginBottom: '3vh',
 });

--- a/src/Components/CabinetManageItem/CabinetManageItem.tsx
+++ b/src/Components/CabinetManageItem/CabinetManageItem.tsx
@@ -140,4 +140,7 @@ const CabinetPhotoContainer = styled('div')({
 
 const TextFieldContainer = styled('div')({
   marginTop: '24px',
+  display: 'flex',
+  // justifyContent: 'space-evenly',
+  columnGap: '2.5vw',
 });

--- a/src/Components/CabinetManageModal/CabinetManageModal.tsx
+++ b/src/Components/CabinetManageModal/CabinetManageModal.tsx
@@ -55,6 +55,7 @@ const PageContainer = styled('div')({
   overflow: 'auto',
   backgroundColor: 'white',
   border: '2px solid #000',
+  borderRadius: '1rem',
   boxShadow:
     '0px 3px 5px -1px rgb(0 0 0 / 20%), 0px 5px 8px 0px rgb(0 0 0 / 14%), 0px 1px 14px 0px rgb(0 0 0 / 12%)',
   padding: '16px 32px 24px',

--- a/src/Components/MenuInfo/MenuInfo.tsx
+++ b/src/Components/MenuInfo/MenuInfo.tsx
@@ -8,6 +8,8 @@ import { useObject } from '../../hooks/useObject';
 import { useAppSelector, useUserSelector } from '../../redux/hooks';
 import { useMediaQuery } from 'react-responsive';
 import media from '../../lib/styles/media';
+import { useAppDispatch } from '../../redux/hooks';
+import { clearUserInfo } from '../../redux/user/userSlice';
 
 type MenuInfoProps = {
   openHelpModal?: React.MouseEventHandler<HTMLLIElement>;
@@ -16,13 +18,18 @@ type MenuInfoProps = {
 export default function MenuInfo({ openHelpModal }: MenuInfoProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const { name } = useAppSelector(useUserSelector);
+  const history = useHistory();
+  const dispatch = useAppDispatch();
   const handleClose = useCallback(() => {
     setAnchorEl(null);
   }, []);
   const handleClick = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(e.currentTarget);
   }, []);
+
   const onClickLogout = useCallback(() => {
+    dispatch(clearUserInfo());
+    history.push('/');
     auth.signOut();
   }, []);
 

--- a/src/redux/user/userSlice.ts
+++ b/src/redux/user/userSlice.ts
@@ -40,9 +40,17 @@ export const userSlice = createSlice({
       state.name = info.name;
       state.studentID = info.studentID;
     },
+    clearUserInfo: (state) => {
+      state.uuid = userInitialState.uuid;
+      state.adminType = userInitialState.adminType;
+      state.cabinetIdx = userInitialState.cabinetIdx;
+      state.cabinetTitle = userInitialState.cabinetTitle;
+      state.name = userInitialState.name;
+      state.studentID = userInitialState.studentID;
+    },
   },
 });
 
-export const { setUserUID, setUserInfo } = userSlice.actions;
+export const { setUserUID, setUserInfo, clearUserInfo } = userSlice.actions;
 
 export default userSlice.reducer;


### PR DESCRIPTION
## 변경 사항
1. CabinetManage UI 변경
2. Cabinet UI 변경
3. 헤더 로그아웃 버그 임시 해결
-> auth.signOut() 실행시 redux에 남은 값들과 페이지에서 필요로 하는 값들이 충돌하는 것 같아 redux에서 user state 초기화 하는 `clearUserInfo` 액션 디스패치한 뒤 history를 mainpage로 이동 시킨 다음 `auth.signOut()` 실행하는 방식으로 임시 해결했습니다